### PR TITLE
feat: Rename new expense button to "Novo"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1096,7 +1096,7 @@
                                     Excluir
                                 </button>
                                 <button id="lancar-despesa-btn" class="inline-flex items-center justify-center rounded-md bg-[var(--primary-color)] px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--primary-color)]">
-                                    + Lançar Nova Despesa
+                                    Novo
                                 </button>
                             </div>
                         </div>


### PR DESCRIPTION
Per user request, the button text for creating a new expense has been changed from "+ Lançar Nova Despesa" to "Novo".