### PR TITLE
fix: Use absolute path for login background image

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,9 @@
     .cliente-tab-link, .funcionario-tab-link, .fornecedor-tab-link {
         /* Applying Tailwind classes directly in CSS is incorrect. This will be moved to the HTML. */
     }
+    .login-background {
+      background-image: url('/login.png');
+    }
   </style>
 </head>
 
@@ -56,7 +59,7 @@
 
   <!-- Container da Tela de Login -->
   <div id="login-page" class="view-container min-h-screen w-full">
-    <div class="hidden lg:block lg:w-1/2 bg-cover bg-center" style="background-image: url('login.png')">
+    <div class="hidden lg:block lg:w-1/2 bg-cover bg-center login-background">
       <div class="flex h-full w-full bg-black bg-opacity-25 items-end p-12">
         <div class="text-white">
           <h1 class="text-4xl font-bold leading-tight">Projetando o futuro, um projeto de cada vez.</h1>


### PR DESCRIPTION
Changes the CSS to use `url('/login.png')` to ensure the image is loaded from the web server's root, which is a more robust pathing strategy.